### PR TITLE
Remove event id

### DIFF
--- a/audio-knife/src/main.rs
+++ b/audio-knife/src/main.rs
@@ -153,7 +153,7 @@ fn process_request(
                 format: DEFAULT_FORMAT,
                 samples: audio::from_le_bytes(samples),
             };
-            context_switch.broadcast_audio(None, frame)?;
+            context_switch.broadcast_audio(frame)?;
             Ok(())
         }
         Message::Ping(payload) => {

--- a/core/src/endpoint.rs
+++ b/core/src/endpoint.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use serde::de::DeserializeOwned;
 use tokio::sync::mpsc::Sender;
 
-use crate::{AudioFrame, EventId, InputModality, OutputModality};
+use crate::{AudioFrame, InputModality, OutputModality};
 
 #[async_trait]
 pub trait Endpoint: fmt::Debug {
@@ -39,18 +39,18 @@ pub trait Endpoint: fmt::Debug {
 pub enum Output {
     Audio { frame: AudioFrame },
     Text { is_final: bool, content: String },
-    Completed { event_id: Option<EventId> },
+    Completed,
     // TODO: Need to add an error output here, see for example the Azure synthesizer.
 }
 
 #[async_trait]
 pub trait Conversation: fmt::Debug {
-    fn post_audio(&mut self, event_id: Option<EventId>, _frame: AudioFrame) -> Result<()> {
-        bail!("This conversion does not support audio input (event: {event_id:?})")
+    fn post_audio(&mut self, _frame: AudioFrame) -> Result<()> {
+        bail!("This conversion does not support audio input")
     }
 
-    fn post_text(&mut self, event_id: Option<EventId>, _text: String) -> Result<()> {
-        bail!("This conversation does not support text input (event: {event_id:?}")
+    fn post_text(&mut self, _text: String) -> Result<()> {
+        bail!("This conversation does not support text input")
     }
 
     /// The implementation of `stop()` should end _all_ pending tasks, even if they need to be

--- a/core/src/protocol.rs
+++ b/core/src/protocol.rs
@@ -1,14 +1,9 @@
 //! Low-level serializable types that are used in the context-switch protocol and internal
 //! endpoint interfaces.
 
-use derive_more::derive::{Display, From, Into};
 use serde::{Deserialize, Serialize};
 
 use crate::{AudioConsumer, AudioProducer, audio_channel};
-
-/// Event identifier. Used to associate server events with client events.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, From, Into, Display, Serialize, Deserialize)]
-pub struct EventId(String);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/endpoints/azure/src/transcribe.rs
+++ b/endpoints/azure/src/transcribe.rs
@@ -2,9 +2,9 @@ use anyhow::{Result, bail};
 use async_stream::stream;
 use async_trait::async_trait;
 use azure_speech::recognizer::{self, Event, WavType};
-use context_switch_core::{AudioConsumer, EventId, InputModality, OutputModality, audio};
 use context_switch_core::{
-    AudioFrame, AudioProducer, Conversation, Endpoint, Output, audio_channel, transcribe,
+    AudioConsumer, AudioFrame, AudioProducer, Conversation, Endpoint, InputModality, Output,
+    OutputModality, audio, audio_channel, transcribe,
 };
 use futures::{Stream, StreamExt};
 use serde::Deserialize;
@@ -125,7 +125,7 @@ struct Transcriber {
 
 #[async_trait]
 impl Conversation for Transcriber {
-    fn post_audio(&mut self, _event_id: Option<EventId>, frame: AudioFrame) -> Result<()> {
+    fn post_audio(&mut self, frame: AudioFrame) -> Result<()> {
         self.input_producer.produce(frame)
     }
 

--- a/examples/endpoint.rs
+++ b/examples/endpoint.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
         select! {
             input = input_consumer.consume() => {
                 if let Some(frame) = input {
-                    conversation.post_audio(None,frame)?;
+                    conversation.post_audio(frame)?;
                 }
                 else {
                     println!("End of input");

--- a/examples/synthesize.rs
+++ b/examples/synthesize.rs
@@ -63,7 +63,6 @@ async fn main() -> Result<()> {
 
     context_switch.process(ClientEvent::Text {
         id: conversation_id.clone(),
-        event_id: None,
         content: text.into(),
     })?;
     let (output_producer, playback_task) = setup_audio_playback(output_format).await;

--- a/src/context_switch.rs
+++ b/src/context_switch.rs
@@ -12,7 +12,7 @@ use tokio::{
 };
 use tracing::{Level, info, span};
 
-use crate::{ClientEvent, ConversationId, EventId, InputModality, ServerEvent, registry::Registry};
+use crate::{ClientEvent, ConversationId, InputModality, ServerEvent, registry::Registry};
 
 #[derive(Debug)]
 pub struct ContextSwitch {
@@ -166,17 +166,22 @@ impl ContextSwitch {
                             ClientEvent::Stop { .. } => {
                                 break;
                             },
-                            ClientEvent::Audio { samples, event_id, .. } => {
+                            ClientEvent::Audio { samples, .. } => {
                                 if let InputModality::Audio { format } = input_modality {
                                     let frame = AudioFrame { format, samples: samples.into() };
-                                    conversation.post_audio(event_id,frame)?;
+                                    conversation.post_audio(frame)?;
                                 } else {
                                     bail!("Received unexpected Audio");
                                 }
                             },
-                            ClientEvent::Text { content, event_id,.. } => {
+                            ClientEvent::Text { content, ..
+
+
+
+
+                            } => {
                                 if let InputModality::Text = input_modality {
-                                    conversation.post_text(event_id,content)?;
+                                    conversation.post_text(content)?;
                                 } else {
                                     bail!("Received unexpected Text");
                                 }
@@ -207,13 +212,12 @@ impl ContextSwitch {
 
     /// Broadcast audio to all active conversations which match the audio format in their input
     /// modality.
-    pub fn broadcast_audio(&self, event_id: Option<EventId>, frame: AudioFrame) -> Result<()> {
+    pub fn broadcast_audio(&self, frame: AudioFrame) -> Result<()> {
         for (id, conversation) in &self.conversations {
             if conversation.input_modality.can_receive_audio(frame.format) {
                 // TODO: An error here should be handled no the way that all other conversations won't receive the audio frame.
                 conversation.client_sender.try_send(ClientEvent::Audio {
                     id: id.clone(),
-                    event_id: event_id.clone(),
                     // TODO: If there is only one conversation that accepts this frame, we should
                     // move it into the event.
                     samples: frame.samples.clone().into(),
@@ -235,9 +239,6 @@ fn output_to_server_event(id: &ConversationId, output: Output) -> ServerEvent {
             is_final,
             content,
         },
-        Output::Completed { event_id } => ServerEvent::Completed {
-            id: id.clone(),
-            event_id,
-        },
+        Output::Completed => ServerEvent::Completed { id: id.clone() },
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -30,14 +30,10 @@ pub enum ClientEvent {
     },
     Audio {
         id: ConversationId,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        event_id: Option<EventId>,
         samples: Samples,
     },
     Text {
         id: ConversationId,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        event_id: Option<EventId>,
         content: String,
     },
 }
@@ -87,8 +83,6 @@ pub enum ServerEvent {
     /// the `event_id` set and the event has been fully processed and completed.
     Completed {
         id: ConversationId,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        event_id: Option<EventId>,
     },
 }
 


### PR DESCRIPTION
It's not needed for now, and since conversation protocols run always ordered and in sequence, it might not be needed in the future.