### PR TITLE
Implement optional base64 message support in audio-knife

### DIFF
--- a/audio-knife/Cargo.toml
+++ b/audio-knife/Cargo.toml
@@ -17,6 +17,7 @@ tracing = { workspace = true }
 dotenvy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+base64 = "0.22.1"
 
 context-switch = { path = ".." }
 context-switch-core = { workspace = true }


### PR DESCRIPTION
This gets around situation in which the json contains spaces and confuses the argument parser in mod_audio_fork. Base64 encoded metadata must be prefixed with `base64:`, but may be the default in future updates.
