### PR TITLE
Rename ServerEvent::Completed to RequestCompleted

### DIFF
--- a/examples/synthesize.rs
+++ b/examples/synthesize.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
                         let frame = AudioFrame { format: output_format, samples: samples.into()};
                         output_producer.produce(frame)?;
                     },
-                    Some(ServerEvent::Completed {..}) => {
+                    Some(ServerEvent::RequestCompleted {..}) => {
                         println!("Synthesize completed");
                     }
                     _ => {

--- a/src/context_switch.rs
+++ b/src/context_switch.rs
@@ -234,6 +234,6 @@ fn output_to_server_event(id: &ConversationId, output: Output) -> ServerEvent {
             is_final,
             content,
         },
-        Output::Completed => ServerEvent::Completed { id: id.clone() },
+        Output::Completed => ServerEvent::RequestCompleted { id: id.clone() },
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -81,7 +81,7 @@ pub enum ServerEvent {
     },
     /// A completed event is sent when the client request that triggered Audio or Text responses has
     /// has been fully processed.
-    Completed {
+    RequestCompleted {
         id: ConversationId,
     },
 }


### PR DESCRIPTION
Clearly indicate in the name of the event what exactly has been completed.
