### PR TITLE
EventScheduler needs to consider the correct AudioFormat for duration computation.

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -161,9 +161,7 @@ impl AudioFrame {
     }
 
     pub fn duration(&self) -> Duration {
-        let mono_sample_count = self.samples.len() / self.format.channels as usize;
-        let sample_rate = self.format.sample_rate;
-        Duration::from_secs_f64(mono_sample_count as f64 / sample_rate as f64)
+        self.format.duration(self.samples.len())
     }
 
     pub fn into_mono(self) -> AudioFrame {

--- a/core/src/protocol.rs
+++ b/core/src/protocol.rs
@@ -1,6 +1,8 @@
 //! Low-level serializable types that are used in the context-switch protocol and internal
 //! endpoint interfaces.
 
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -21,6 +23,11 @@ impl AudioFormat {
             channels,
             sample_rate,
         }
+    }
+
+    pub fn duration(&self, no_samples: usize) -> Duration {
+        let mono_sample_count = no_samples / self.channels as usize;
+        Duration::from_secs_f64(mono_sample_count as f64 / self.sample_rate as f64)
     }
 
     pub fn new_channel(&self) -> (AudioProducer, AudioConsumer) {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,6 +1,6 @@
 use base64::prelude::*;
 use context_switch_core::audio;
-use derive_more::derive::{Display, From, Into};
+use derive_more::derive::{Deref, Display, From, Into};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Conversation identifier.
@@ -94,14 +94,8 @@ pub enum ServerEvent {
 
 /// A type that represents samples in Vec<i16> format in memory, but serializes them as a
 /// base64 string.
-#[derive(Debug, Clone, Into, From)]
+#[derive(Debug, Clone, Into, From, Deref)]
 pub struct Samples(Vec<i16>);
-
-impl Samples {
-    pub fn samples(&self) -> &[i16] {
-        &self.0
-    }
-}
 
 /// Serializer for Samples
 /// (we could perhaps use serde_with, but it does not seem to consider endianess)


### PR DESCRIPTION
... because we now support other formats than 16khz mono in audio-knife.