### PR TITLE
Share the ContextSwitch instance in AudioKnife

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,24 +13,33 @@ members = [
 ]
 
 [dependencies]
-context-switch-core = { workspace = true }
-cs-azure = { workspace = true }
-openai-dialog = { path = "endpoints/openai-dialog" }
 
+# ours
+
+context-switch-core = { workspace = true }
+
+openai-dialog = { path = "endpoints/openai-dialog" }
+cs-azure = { workspace = true }
 azure-speech = { workspace = true }
 
-serde = { workspace = true }
-tokio = { workspace = true }
+# basic
+
+static_assertions = { workspace = true }
 anyhow = { workspace = true }
-async-trait = { workspace = true }
 base64 = { workspace = true }
 tracing = {workspace = true }
+futures = "0.3.31"
+derive_more = { workspace = true }
+
+# serialization / async runtime
+
+serde = { workspace = true }
+serde_json = "1.0.133"
+tokio = { workspace = true }
+async-trait = { workspace = true }
 
 # todo: is this needed?
 uuid = "1.11.0"
-serde_json = "1.0.133"
-futures = "0.3.31"
-derive_more = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }
@@ -56,6 +65,7 @@ cs-azure = { path = "endpoints/azure" }
 
 anyhow = "1.0.93"
 derive_more = { version = "1.0.0", features = ["full"] }
+static_assertions = "1.1.0"
 async-stream = { version = "0.3.6" }
 tokio = { version = "1.41.1", features = ["sync"] }
 futures = "0.3.31"

--- a/audio-knife/src/server_event_splitter.rs
+++ b/audio-knife/src/server_event_splitter.rs
@@ -1,0 +1,50 @@
+//! A component to split server events to multiple conversation targets.
+use std::collections::HashMap;
+
+use anyhow::{Result, anyhow, bail};
+use tokio::sync::mpsc::Sender;
+
+use context_switch::{ConversationId, ServerEvent};
+
+#[derive(Debug, Default)]
+pub struct ServerEventSplitter {
+    conversation_targets: HashMap<ConversationId, Sender<ServerEvent>>,
+}
+
+impl ServerEventSplitter {
+    pub fn dispatch(&mut self, event: ServerEvent) -> Result<()> {
+        let conversation = event.conversation_id();
+
+        match self.conversation_targets.get(conversation) {
+            Some(sender) => sender.try_send(event)?,
+            None => bail!("Conversation does not exist: {conversation}"),
+        };
+
+        Ok(())
+    }
+
+    pub fn add_conversation_target(
+        &mut self,
+        conversation: impl Into<ConversationId>,
+        target: Sender<ServerEvent>,
+    ) -> Result<()> {
+        if self
+            .conversation_targets
+            .insert(conversation.into(), target)
+            .is_none()
+        {
+            bail!("Conversation already exists")
+        }
+
+        Ok(())
+    }
+
+    pub fn remove_conversation_target(
+        &mut self,
+        conversation: &ConversationId,
+    ) -> Result<Sender<ServerEvent>> {
+        self.conversation_targets
+            .remove(conversation)
+            .ok_or(anyhow!("Conversation does not exist"))
+    }
+}

--- a/src/context_switch.rs
+++ b/src/context_switch.rs
@@ -5,6 +5,7 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use context_switch_core::{AudioFrame, Output};
+use static_assertions::assert_impl_all;
 use tokio::{
     select,
     sync::mpsc::{Receiver, Sender, channel},
@@ -20,6 +21,7 @@ pub struct ContextSwitch {
     conversations: HashMap<ConversationId, ActiveConversation>,
     output: Sender<ServerEvent>,
 }
+assert_impl_all!(ContextSwitch: Send);
 
 #[derive(Debug)]
 struct ActiveConversation {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -92,6 +92,20 @@ pub enum ServerEvent {
     },
 }
 
+impl ServerEvent {
+    pub fn conversation_id(&self) -> &ConversationId {
+        match self {
+            ServerEvent::Started { id, .. }
+            | ServerEvent::Stopped { id }
+            | ServerEvent::Error { id, .. }
+            | ServerEvent::Audio { id, .. }
+            | ServerEvent::Text { id, .. }
+            | ServerEvent::RequestCompleted { id }
+            | ServerEvent::ClearAudio { id } => id,
+        }
+    }
+}
+
 /// A type that represents samples in Vec<i16> format in memory, but serializes them as a
 /// base64 string.
 #[derive(Debug, Clone, Into, From, Deref)]


### PR DESCRIPTION
This is a preparation to support cross-conversation audio delivery, for example for use with translation services while the participants are bridged in FreeSWITCH.