### PR TITLE
Support to override the billing scope for the remote playback option

### DIFF
--- a/core/src/conversation.rs
+++ b/core/src/conversation.rs
@@ -278,6 +278,7 @@ pub enum Input {
         request_id: Option<RequestId>,
         text: String,
         text_type: Option<String>,
+        billing_scope: Option<String>,
     },
     ServiceEvent {
         value: serde_json::Value,

--- a/examples/aristech-synthesize.rs
+++ b/examples/aristech-synthesize.rs
@@ -57,6 +57,7 @@ async fn main() -> Result<()> {
             request_id: None,
             text: SAMPLE_TEXT.to_string(),
             text_type: None,
+            billing_scope: None,
         })
         .await
         .context("Failed to send text input")?;

--- a/examples/azure-synthesize.rs
+++ b/examples/azure-synthesize.rs
@@ -68,6 +68,7 @@ async fn main() -> Result<()> {
         id: conversation_id.clone(),
         content: text.into(),
         content_type: None,
+        billing_scope: None,
     })?;
     let (output_producer, playback_task) = setup_audio_playback(output_format).await;
 

--- a/services/aristech/src/synthesize.rs
+++ b/services/aristech/src/synthesize.rs
@@ -82,9 +82,7 @@ impl Service for AristechSynthesize {
             };
 
             let Input::Text {
-                request_id,
-                text,
-                text_type: _,
+                request_id, text, ..
             } = input
             else {
                 bail!("Unexpected input");

--- a/services/azure/src/synthesize.rs
+++ b/services/azure/src/synthesize.rs
@@ -79,6 +79,7 @@ impl Service for AzureSynthesize {
                 request_id,
                 text,
                 text_type,
+                ..
             } = input
             else {
                 bail!("Unexpected input");

--- a/services/playback/src/lib.rs
+++ b/services/playback/src/lib.rs
@@ -58,6 +58,7 @@ impl Service for Playback {
                     request_id,
                     text,
                     text_type,
+                    billing_scope,
                 } => {
                     let text_type = text_type.as_deref().unwrap_or("text/plain");
                     let method = PlaybackMethod::from_text_and_mime_type(
@@ -76,6 +77,7 @@ impl Service for Playback {
                                         request_id,
                                         text,
                                         text_type: Some(text_type),
+                                        billing_scope: None,
                                     },
                                 )
                                 .await?;
@@ -131,7 +133,7 @@ impl Service for Playback {
                                         // Write billing records and complete the request inside the spawn_blocking
                                         output.billing_records(
                                             request_id.clone(),
-                                            None,
+                                            billing_scope.clone(),
                                             [BillingRecord::duration("playback:remote", duration)],
                                         )
                                     },

--- a/src/context_switch.rs
+++ b/src/context_switch.rs
@@ -269,10 +269,10 @@ async fn process_conversation_protected(
                             bail!("Received unexpected Audio");
                         }
                     },
-                    ClientEvent::Text { content, content_type, .. } => {
+                    ClientEvent::Text { content, content_type, billing_scope,.. } => {
                         if let InputModality::Text = input_modality {
                             input_sender
-                                .try_send(Input::Text { request_id: None, text: content, text_type: content_type })
+                                .try_send(Input::Text { request_id: None, text: content, text_type: content_type, billing_scope })
                                 .context("Sending input text to conversation")?;
                         } else {
                             bail!("Received unexpected Text");

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -48,6 +48,7 @@ pub enum ClientEvent {
         id: ConversationId,
         content: String,
         content_type: Option<String>,
+        billing_scope: Option<String>,
     },
     Service {
         id: ConversationId,


### PR DESCRIPTION
For situations in which no billing scope is used, it's useful to override it, specifically for remote playbacks which may be billed depending what's being played back.