### PR TITLE
Make all output path channels unbounded

### DIFF
--- a/audio-knife/src/event_scheduler.rs
+++ b/audio-knife/src/event_scheduler.rs
@@ -14,7 +14,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use tokio::{
     select,
-    sync::mpsc::{Receiver, Sender},
+    sync::mpsc::{Sender, UnboundedReceiver},
     time::sleep,
 };
 use tracing::{debug, warn};
@@ -26,7 +26,7 @@ use context_switch::{AudioFormat, OutputModality, OutputPath, ServerEvent};
 /// This delays audio pakets if more than 5 seconds are pending, and control pakets if currently
 /// audio is being assumed to be played back.
 pub async fn event_scheduler(
-    mut receiver: Receiver<ServerEvent>,
+    mut receiver: UnboundedReceiver<ServerEvent>,
     sender: Sender<ServerEvent>,
 ) -> Result<()> {
     let mut media_scheduler = MediaEventScheduler::new();

--- a/audio-knife/src/main.rs
+++ b/audio-knife/src/main.rs
@@ -31,7 +31,7 @@ use server_event_router::ServerEventRouter;
 use tokio::{
     net::TcpListener,
     pin, select,
-    sync::mpsc::{Receiver, Sender, channel},
+    sync::mpsc::{Receiver, Sender, UnboundedReceiver, channel, unbounded_channel},
 };
 use tracing::{Instrument, Span, debug, error, info, info_span};
 
@@ -87,8 +87,11 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Channel from context_switch to event_scheduler
-    let (cs_sender, cs_receiver) = channel(32);
+    // Channel from context_switch to event_scheduler.
+    //
+    // Since we can't block audio data that is sent here, we need an unbounded channel here, for
+    // now.
+    let (cs_sender, cs_receiver) = unbounded_channel();
 
     let server_event_distributor = Arc::new(Mutex::new(ServerEventRouter::default()));
 
@@ -133,7 +136,7 @@ async fn main() -> Result<()> {
 }
 
 async fn server_event_dispatcher(
-    mut receiver: Receiver<ServerEvent>,
+    mut receiver: UnboundedReceiver<ServerEvent>,
     distributor: Arc<Mutex<ServerEventRouter>>,
 ) -> Result<()> {
     loop {
@@ -207,7 +210,7 @@ async fn ws(state: State, mut websocket: WebSocket) -> Result<()> {
 
 async fn ws_session(
     mut session_state: SessionState,
-    cs_receiver: Receiver<ServerEvent>,
+    cs_receiver: UnboundedReceiver<ServerEvent>,
     websocket: WebSocket,
 ) -> Result<()> {
     let (ws_sender, mut ws_receiver) = websocket.split();
@@ -300,7 +303,10 @@ impl Drop for SessionState {
 }
 
 impl SessionState {
-    fn start_session(state: State, msg: Message) -> Result<(Self, Span, Receiver<ServerEvent>)> {
+    fn start_session(
+        state: State,
+        msg: Message,
+    ) -> Result<(Self, Span, UnboundedReceiver<ServerEvent>)> {
         let Message::Text(msg) = msg else {
             // What about Ping?
             bail!("Expecting first WebSocket message to be text");
@@ -350,7 +356,8 @@ impl SessionState {
             None
         };
 
-        let (se_sender, se_receiver) = channel(32);
+        // Output path is unbounded for now.
+        let (se_sender, se_receiver) = unbounded_channel();
 
         state
             .server_event_distributor

--- a/examples/aristech-synthesize.rs
+++ b/examples/aristech-synthesize.rs
@@ -2,7 +2,10 @@ use std::{env, thread, time::Duration};
 
 use anyhow::{Context as AnyhowContext, Result};
 use rodio::{OutputStreamBuilder, Sink, Source};
-use tokio::{select, sync::mpsc::channel};
+use tokio::{
+    select,
+    sync::mpsc::{channel, unbounded_channel},
+};
 
 use aristech::synthesize::{AristechSynthesize, Params as AristechParams};
 use context_switch::{InputModality, OutputModality};
@@ -33,7 +36,7 @@ async fn main() -> Result<()> {
     let params = get_aristech_params()?;
 
     // Set up channels for the conversation
-    let (output_producer, mut output_consumer) = channel(32);
+    let (output_producer, mut output_consumer) = unbounded_channel();
     let (conv_input_producer, conv_input_consumer) = channel(32);
 
     // Create the service and conversation

--- a/examples/aristech-transcribe.rs
+++ b/examples/aristech-transcribe.rs
@@ -2,7 +2,10 @@ use std::{env, time::Duration};
 
 use anyhow::{Context, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use tokio::{select, sync::mpsc::channel};
+use tokio::{
+    select,
+    sync::mpsc::{channel, unbounded_channel},
+};
 
 use aristech::transcribe::{ApiKeyAuth, AuthConfig, CredentialsAuth, Params as AristechParams};
 use context_switch::{InputModality, OutputModality, services::AristechTranscribe};
@@ -93,7 +96,7 @@ async fn main() -> Result<()> {
         prompt: None, // Optional: Specify a prompt if needed
     };
 
-    let (output_producer, mut output_consumer) = channel(32);
+    let (output_producer, mut output_consumer) = unbounded_channel();
     let (conv_input_producer, conv_input_consumer) = channel(32);
 
     let aristech = AristechTranscribe;

--- a/examples/azure-synthesize.rs
+++ b/examples/azure-synthesize.rs
@@ -4,7 +4,10 @@ use std::{env, thread, time::Duration};
 
 use anyhow::{Result, bail};
 use rodio::{OutputStreamBuilder, Sink, Source};
-use tokio::{select, sync::mpsc::channel};
+use tokio::{
+    select,
+    sync::mpsc::{channel, unbounded_channel},
+};
 
 use context_switch::{ClientEvent, ContextSwitch, ConversationId, OutputModality, ServerEvent};
 use context_switch_core::{AudioFormat, AudioFrame, AudioProducer, audio};
@@ -24,7 +27,7 @@ async fn main() -> Result<()> {
 
     let text = "In a small village, surrounded by dense forests and gentle hills, there once lived an inventive tinkerer who built machines that amazed people.";
 
-    let (server_events_tx, mut server_events_rx) = channel(16);
+    let (server_events_tx, mut server_events_rx) = unbounded_channel();
 
     let conversation_id = ConversationId::from("synthesize-conversation".to_string());
 

--- a/examples/azure-transcribe.rs
+++ b/examples/azure-transcribe.rs
@@ -2,7 +2,10 @@ use std::{env, time::Duration};
 
 use anyhow::{Context, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use tokio::{select, sync::mpsc::channel};
+use tokio::{
+    select,
+    sync::mpsc::{channel, unbounded_channel},
+};
 
 use context_switch::{InputModality, OutputModality, services::AzureTranscribe};
 use context_switch_core::{
@@ -64,7 +67,7 @@ async fn main() -> Result<()> {
         language: language.into(),
     };
 
-    let (output_producer, mut output_consumer) = channel(32);
+    let (output_producer, mut output_consumer) = unbounded_channel();
     let (conv_input_producer, conv_input_consumer) = channel(32);
 
     let azure = AzureTranscribe;

--- a/examples/azure-translate.rs
+++ b/examples/azure-translate.rs
@@ -14,7 +14,7 @@ use context_switch_core::{
 };
 use tokio::{
     select,
-    sync::mpsc::{Receiver, channel},
+    sync::mpsc::{UnboundedReceiver, channel, unbounded_channel},
 };
 
 #[tokio::main]
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
         target_voice: None,
     };
 
-    let (output_sender, output_receiver) = channel(256);
+    let (output_sender, output_receiver) = unbounded_channel();
 
     let conversation = Conversation::new(
         InputModality::Audio { format },
@@ -120,7 +120,7 @@ enum AudioCommand {
 
 async fn setup_audio_playback(
     format: AudioFormat,
-    mut output: Receiver<Output>,
+    mut output: UnboundedReceiver<Output>,
 ) -> impl std::future::Future<Output = ()> {
     let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
 

--- a/justfile
+++ b/justfile
@@ -1,2 +1,5 @@
 knife:
     cargo run -p audio-knife
+
+knife-release:
+    cargo run -p audio-knife --release

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,14 +2,14 @@ use std::time::Duration;
 
 use helper::*;
 use serde_json::Value;
-use tokio::sync::mpsc::channel;
+use tokio::sync::mpsc::{channel, unbounded_channel};
 
 use crate::{ClientEvent, ContextSwitch, ConversationId, Registry, ServerEvent};
 use context_switch_core::InputModality;
 
 #[tokio::test]
 async fn never_ending_service_shut_downs_gracefully_in_response_to_stop() {
-    let (server_sender, mut server_receiver) = channel(256);
+    let (server_sender, mut server_receiver) = unbounded_channel();
 
     let (n_send, mut n_recv) = channel(10);
 
@@ -55,7 +55,7 @@ async fn never_ending_service_shut_downs_gracefully_in_response_to_stop() {
 // #[tokio::test]
 #[allow(unused)]
 async fn output_events_can_be_sent_after_shutdown() {
-    let (server_sender, mut server_receiver) = channel(256);
+    let (server_sender, mut server_receiver) = unbounded_channel();
 
     let (n_send, mut n_recv) = channel(10);
 


### PR DESCRIPTION
... because we can't block on the audio production side yet. This is an issue for playing back long files. In the test case we played back a mp3 of about 4 minutes length for which playback failed after about 15 seconds audio data was read and pushed as frames.
