### PR TITLE
Remove SessionUpdated service event from google dialog

### DIFF
--- a/.github/workflows/context-switch.yml
+++ b/.github/workflows/context-switch.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]  # Run on default branch only
   pull_request:
-    branches: [ master ]  # Run on pull requests targeting default branch
+    branches: [ '**' ]  # Run on pull requests targeting any branch
 
 jobs:
   code-quality:

--- a/.github/workflows/context-switch.yml
+++ b/.github/workflows/context-switch.yml
@@ -2,9 +2,9 @@ name: Context Switch CI
 
 on:
   push:
-    branches: [ '**' ]  # Run on all branches
+    branches: [ master ]  # Run on default branch only
   pull_request:
-    branches: [ '**' ]  # Run on all pull requests
+    branches: [ master ]  # Run on pull requests targeting default branch
 
 jobs:
   code-quality:

--- a/examples/dialog_providers/google.rs
+++ b/examples/dialog_providers/google.rs
@@ -63,10 +63,6 @@ impl ProviderApi for GoogleProvider {
                 tracing::info!("Tool call cancelled: {call_id}");
                 Ok(None)
             }
-            ServiceOutputEvent::SessionUpdated { tools } => {
-                tracing::info!("Session updated: {tools:?}");
-                Ok(None)
-            }
         }
     }
 

--- a/services/google-dialog/src/client.rs
+++ b/services/google-dialog/src/client.rs
@@ -2,10 +2,10 @@ use anyhow::{Context, Result, anyhow, bail};
 
 use gemini_live::transport::{Auth, Endpoint, TransportConfig};
 use gemini_live::types::{
-    AudioTranscriptionConfig, Content, ContextWindowCompressionConfig, FunctionDeclaration,
-    FunctionResponse, GenerationConfig, Modality, ModalityTokenCount, Part, PrebuiltVoiceConfig,
-    ServerEvent, SessionResumptionConfig, SetupConfig, SlidingWindow, SpeechConfig, ThinkingConfig,
-    Tool, UsageMetadata, VoiceConfig,
+    AudioTranscriptionConfig, Content, ContextWindowCompressionConfig, FunctionResponse,
+    GenerationConfig, Modality, ModalityTokenCount, Part, PrebuiltVoiceConfig, ServerEvent,
+    SessionResumptionConfig, SetupConfig, SlidingWindow, SpeechConfig, ThinkingConfig,
+    UsageMetadata, VoiceConfig,
 };
 use gemini_live::{ReconnectPolicy, Session, SessionConfig, SessionError};
 use tracing::{debug, info, trace};
@@ -35,17 +35,12 @@ impl Client {
         output: ConversationOutput,
     ) -> Result<()> {
         let billing_scope = self.params.model.clone();
-        let tools = function_declarations(&self.params.tools);
         let mut state = ConversationState::new();
         let mut session = match Session::connect(session_config(&self.params, text_outputs)?).await
         {
             Ok(session) => session,
             Err(error) => return Err(connect_error_with_voice_context(&self.params, error)),
         };
-        output.service_event(
-            OutputPath::Control,
-            ServiceOutputEvent::SessionUpdated { tools },
-        )?;
 
         loop {
             tokio::select! {
@@ -252,20 +247,6 @@ fn normalize_function_response(output: serde_json::Value) -> serde_json::Value {
         // Gemini requires functionResponse.response to be a protobuf Struct, i.e. a JSON object.
         value => serde_json::json!({ "result": value }),
     }
-}
-
-fn function_declarations(tools: &[Tool]) -> Option<Vec<FunctionDeclaration>> {
-    let declarations: Vec<_> = tools
-        .iter()
-        .filter_map(|tool| match tool {
-            Tool::FunctionDeclarations(declarations) => Some(declarations.as_slice()),
-            Tool::GoogleSearch(_) => None,
-        })
-        .flatten()
-        .cloned()
-        .collect();
-
-    (!declarations.is_empty()).then_some(declarations)
 }
 
 fn session_config(params: &Params, text_outputs: TextOutputs) -> Result<SessionConfig> {

--- a/services/google-dialog/src/types.rs
+++ b/services/google-dialog/src/types.rs
@@ -184,10 +184,6 @@ pub enum ServiceOutputEvent {
     },
     #[serde(rename_all = "camelCase")]
     ToolCallCancellation { call_id: String },
-    SessionUpdated {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        tools: Option<Vec<FunctionDeclaration>>,
-    },
 }
 
 #[cfg(test)]


### PR DESCRIPTION
, because currently it's only sent once at the beginning and just reflects the tools passed initially.