### PR TITLE
Fix transcription inconsistencies

### DIFF
--- a/core/src/conversation.rs
+++ b/core/src/conversation.rs
@@ -10,7 +10,7 @@ use crate::{
     billing_context::BillingContext,
 };
 
-pub const AI_AGENT_SPEAKER: &str = "~:ai-agent";
+pub const AI_ASSISTANT_SPEAKER: &str = "~:ai-assistant";
 
 #[derive(Debug)]
 pub struct Conversation {

--- a/core/src/conversation.rs
+++ b/core/src/conversation.rs
@@ -10,6 +10,8 @@ use crate::{
     billing_context::BillingContext,
 };
 
+pub const AI_AGENT_SPEAKER: &str = "~:ai-agent";
+
 #[derive(Debug)]
 pub struct Conversation {
     registry: Arc<Registry>,

--- a/examples/dialog_providers/openai.rs
+++ b/examples/dialog_providers/openai.rs
@@ -44,6 +44,8 @@ impl ProviderApi for OpenAIProvider {
             .map(parse_realtime_voice_value)
             .transpose()?;
         params.tools.push(get_time_function_definition());
+        params.input_audio_transcription = true;
+        params.output_audio_transcription = true;
 
         OpenAIDialog.conversation(params, conversation).await
     }

--- a/services/google-dialog/src/client.rs
+++ b/services/google-dialog/src/client.rs
@@ -176,7 +176,7 @@ impl Client {
                     // Observed with preview Gemini models: transcription events can still arrive
                     // even when transcription is not enabled in setup.
                     warn!(
-                        transcript = %text,
+                        transcript_len = text.len(),
                         "Received input transcription event while input_audio_transcription is disabled (observed with preview model)"
                     );
                 }

--- a/services/google-dialog/src/client.rs
+++ b/services/google-dialog/src/client.rs
@@ -196,7 +196,7 @@ impl Client {
                     // Observed with preview Gemini models: transcription events can still arrive
                     // even when transcription is not enabled in setup.
                     warn!(
-                        transcript = %text,
+                        transcript_len = text.len(),
                         "Received output transcription event while output_audio_transcription is disabled (observed with preview model)"
                     );
                 }

--- a/services/google-dialog/src/client.rs
+++ b/services/google-dialog/src/client.rs
@@ -280,7 +280,7 @@ impl Client {
 fn normalize_function_response(output: serde_json::Value) -> serde_json::Value {
     match output {
         serde_json::Value::Object(_) => output,
-        // Gemini requires functionResponse.response to be a protobuf Struct, i.e. a JSON object.
+        // Gemini requires `functionResponse.response` to be a protobuf struct, i.e. a JSON object.
         value => serde_json::json!({ "result": value }),
     }
 }

--- a/services/google-dialog/src/client.rs
+++ b/services/google-dialog/src/client.rs
@@ -15,8 +15,8 @@ use tracing::{debug, info, trace, warn};
 use crate::conversation_state::ConversationState;
 use crate::{Params, ServiceInputEvent, ServiceOutputEvent, TextOutputs};
 use context_switch_core::{
-    AI_AGENT_SPEAKER, AudioFormat, AudioFrame, BillingRecord, BillingSchedule, ConversationInput,
-    ConversationOutput, Input, OutputPath,
+    AI_ASSISTANT_SPEAKER, AudioFormat, AudioFrame, BillingRecord, BillingSchedule,
+    ConversationInput, ConversationOutput, Input, OutputPath,
 };
 
 #[derive(Debug)]
@@ -189,7 +189,7 @@ impl Client {
                             false,
                             state.output_transcription_buffer.clone(),
                             None,
-                            Some(AI_AGENT_SPEAKER.into()),
+                            Some(AI_ASSISTANT_SPEAKER.into()),
                         )?;
                     }
                 } else {
@@ -268,7 +268,7 @@ impl Client {
         let buffer = mem::take(&mut state.output_transcription_buffer);
 
         if self.params.output_audio_transcription && text_outputs.text && !buffer.is_empty() {
-            output.text(true, buffer, None, Some(AI_AGENT_SPEAKER.into()))?;
+            output.text(true, buffer, None, Some(AI_ASSISTANT_SPEAKER.into()))?;
         }
         Ok(())
     }

--- a/services/google-dialog/src/client.rs
+++ b/services/google-dialog/src/client.rs
@@ -165,9 +165,6 @@ impl Client {
             ServerEvent::Interrupted => {
                 // We expect a TurnComplete afterwards, so don't finalize the output transcription
                 // when interrupted.
-                //
-                // spellcheck: ignore
-                // self.finalize_output_transcription(text_outputs, output, state)?;
                 output.clear_audio()?;
             }
             ServerEvent::InputTranscription(text) => {

--- a/services/google-dialog/src/client.rs
+++ b/services/google-dialog/src/client.rs
@@ -157,7 +157,10 @@ impl Client {
             }
             ServerEvent::GenerationComplete => {}
             ServerEvent::TurnComplete => {
-                if text_outputs.text && !state.output_transcription_buffer.is_empty() {
+                if self.params.output_audio_transcription
+                    && text_outputs.text
+                    && !state.output_transcription_buffer.is_empty()
+                {
                     output.text(
                         true,
                         std::mem::take(&mut state.output_transcription_buffer),
@@ -174,19 +177,37 @@ impl Client {
                 output.clear_audio()?;
             }
             ServerEvent::InputTranscription(text) => {
-                if text_outputs.text {
-                    output.text(true, text, None, None)?;
+                if self.params.input_audio_transcription {
+                    if text_outputs.text {
+                        output.text(true, text, None, None)?;
+                    }
+                } else {
+                    // Observed with preview Gemini models: transcription events can still arrive
+                    // even when transcription is not enabled in setup.
+                    warn!(
+                        transcript = %text,
+                        "Received input transcription event while input_audio_transcription is disabled (observed with preview model)"
+                    );
                 }
             }
             ServerEvent::OutputTranscription(text) => {
-                state.output_transcription_buffer.push_str(&text);
-                if text_outputs.interim {
-                    output.text(
-                        false,
-                        state.output_transcription_buffer.clone(),
-                        None,
-                        Some(self.params.model.clone()),
-                    )?;
+                if self.params.output_audio_transcription {
+                    state.output_transcription_buffer.push_str(&text);
+                    if text_outputs.interim {
+                        output.text(
+                            false,
+                            state.output_transcription_buffer.clone(),
+                            None,
+                            Some(self.params.model.clone()),
+                        )?;
+                    }
+                } else {
+                    // Observed with preview Gemini models: transcription events can still arrive
+                    // even when transcription is not enabled in setup.
+                    warn!(
+                        transcript = %text,
+                        "Received output transcription event while output_audio_transcription is disabled (observed with preview model)"
+                    );
                 }
             }
             ServerEvent::ToolCall(calls) => {

--- a/services/google-dialog/src/client.rs
+++ b/services/google-dialog/src/client.rs
@@ -15,8 +15,8 @@ use tracing::{debug, info, trace, warn};
 use crate::conversation_state::ConversationState;
 use crate::{Params, ServiceInputEvent, ServiceOutputEvent, TextOutputs};
 use context_switch_core::{
-    AudioFormat, AudioFrame, BillingRecord, BillingSchedule, ConversationInput, ConversationOutput,
-    Input, OutputPath,
+    AI_AGENT_SPEAKER, AudioFormat, AudioFrame, BillingRecord, BillingSchedule, ConversationInput,
+    ConversationOutput, Input, OutputPath,
 };
 
 #[derive(Debug)]
@@ -192,7 +192,7 @@ impl Client {
                             false,
                             state.output_transcription_buffer.clone(),
                             None,
-                            Some(self.params.model.clone()),
+                            Some(AI_AGENT_SPEAKER.into()),
                         )?;
                     }
                 } else {
@@ -271,7 +271,7 @@ impl Client {
         let buffer = mem::take(&mut state.output_transcription_buffer);
 
         if self.params.output_audio_transcription && text_outputs.text && !buffer.is_empty() {
-            output.text(true, buffer, None, Some(self.params.model.clone()))?;
+            output.text(true, buffer, None, Some(AI_AGENT_SPEAKER.into()))?;
         }
         Ok(())
     }

--- a/services/google-dialog/src/client.rs
+++ b/services/google-dialog/src/client.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 use anyhow::{Context, Result, anyhow, bail};
 
 use gemini_live::transport::{Auth, Endpoint, TransportConfig};
@@ -157,23 +159,15 @@ impl Client {
             }
             ServerEvent::GenerationComplete => {}
             ServerEvent::TurnComplete => {
-                if self.params.output_audio_transcription
-                    && text_outputs.text
-                    && !state.output_transcription_buffer.is_empty()
-                {
-                    output.text(
-                        true,
-                        std::mem::take(&mut state.output_transcription_buffer),
-                        None,
-                        Some(self.params.model.clone()),
-                    )?;
-                } else {
-                    state.output_transcription_buffer.clear();
-                }
+                self.finalize_output_transcription(text_outputs, output, state)?;
                 output.request_completed(None)?;
             }
             ServerEvent::Interrupted => {
-                state.output_transcription_buffer.clear();
+                // We expect a TurnComplete afterwards, so don't finalize the output transcription
+                // when interrupted.
+                //
+                // spellcheck: ignore
+                // self.finalize_output_transcription(text_outputs, output, state)?;
                 output.clear_audio()?;
             }
             ServerEvent::InputTranscription(text) => {
@@ -266,6 +260,20 @@ impl Client {
             }
         }
         Ok(FlowControl::Continue)
+    }
+
+    fn finalize_output_transcription(
+        &self,
+        text_outputs: TextOutputs,
+        output: &ConversationOutput,
+        state: &mut ConversationState,
+    ) -> Result<()> {
+        let buffer = mem::take(&mut state.output_transcription_buffer);
+
+        if self.params.output_audio_transcription && text_outputs.text && !buffer.is_empty() {
+            output.text(true, buffer, None, Some(self.params.model.clone()))?;
+        }
+        Ok(())
     }
 }
 

--- a/services/openai-dialog/Cargo.toml
+++ b/services/openai-dialog/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 [features]
 default = ["prompt-delay"]
 prompt-delay = []
-interim-output-text-events = []
 
 [dependencies]
 context-switch-core = { workspace = true }

--- a/services/openai-dialog/Cargo.toml
+++ b/services/openai-dialog/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [features]
 default = ["prompt-delay"]
 prompt-delay = []
+interim-output-text-events = []
 
 [dependencies]
 context-switch-core = { workspace = true }

--- a/services/openai-dialog/src/client.rs
+++ b/services/openai-dialog/src/client.rs
@@ -470,7 +470,6 @@ impl Client {
                     output.text(true, text, None, None)?;
                 }
             }
-            #[cfg(feature = "interim-output-text-events")]
             ServerEvent::ResponseOutputAudioTranscriptDelta(
                 server_event::ResponseOutputAudioTranscriptDelta {
                     response_id,
@@ -492,8 +491,6 @@ impl Client {
                     output.text(false, text, None, Some(AI_AGENT_SPEAKER.into()))?;
                 }
             }
-            #[cfg(not(feature = "interim-output-text-events"))]
-            ServerEvent::ResponseOutputAudioTranscriptDelta(..) => {}
             ServerEvent::ResponseOutputAudioTranscriptDone(
                 server_event::ResponseOutputAudioTranscriptDone {
                     response_id,

--- a/services/openai-dialog/src/client.rs
+++ b/services/openai-dialog/src/client.rs
@@ -472,7 +472,7 @@ impl Client {
             }
             ServerEvent::ResponseOutputAudioTranscriptDelta(
                 server_event::ResponseOutputAudioTranscriptDelta {
-                    response_id,
+                    response_id: _,
                     item_id,
                     output_index,
                     content_index,
@@ -482,7 +482,6 @@ impl Client {
             ) => {
                 if transcription.output {
                     let text = self.transcription_state.apply_output_delta(
-                        response_id,
                         item_id,
                         output_index,
                         content_index,
@@ -493,7 +492,7 @@ impl Client {
             }
             ServerEvent::ResponseOutputAudioTranscriptDone(
                 server_event::ResponseOutputAudioTranscriptDone {
-                    response_id,
+                    response_id: _,
                     item_id,
                     output_index,
                     content_index,
@@ -503,7 +502,6 @@ impl Client {
             ) => {
                 if transcription.output
                     && let Some(text) = self.transcription_state.complete_output_transcription(
-                        response_id,
                         item_id,
                         output_index,
                         content_index,
@@ -539,7 +537,7 @@ impl Client {
             ServerEvent::ResponseDone(server_event::ResponseDone {
                 response:
                     types::Response {
-                        id: response_id,
+                        id: _,
                         object,
                         status,
                         output: items,
@@ -628,9 +626,6 @@ impl Client {
                         self.transcription_state.clear_item(item_id);
                     }
                 }
-
-                self.transcription_state
-                    .clear_output_response_tracking(&response_id);
 
                 if let Some(usage) = usage {
                     let input_details = &usage.input_token_details;

--- a/services/openai-dialog/src/client.rs
+++ b/services/openai-dialog/src/client.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "prompt-delay")]
 use std::collections::VecDeque;
-use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result, bail};
 use base64::prelude::*;
@@ -16,6 +15,7 @@ use tracing::{debug, info, trace, warn};
 #[cfg(feature = "prompt-delay")]
 use uuid::Uuid;
 
+use crate::transcription::{TranscriptionSettings, TranscriptionState};
 use crate::{Params, ServiceInputEvent, ServiceOutputEvent};
 use context_switch_core::{
     AI_AGENT_SPEAKER, AudioFormat, AudioFrame, BillingRecord, BillingSchedule,
@@ -29,51 +29,6 @@ pub struct Client {
 
     #[cfg(feature = "prompt-delay")]
     prompt_coordinator: PromptCoordinator,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct TranscriptionSettings {
-    pub input: bool,
-    pub output: bool,
-}
-
-#[derive(Debug, Default)]
-struct TranscriptionState {
-    input_transcription_buffers: HashMap<InputTranscriptionKey, String>,
-    output_transcription_buffers: HashMap<OutputTranscriptionKey, String>,
-    output_transcription_responses: HashSet<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct InputTranscriptionKey {
-    item_id: String,
-    content_index: u32,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct OutputTranscriptionKey {
-    item_id: String,
-    output_index: u32,
-    content_index: u32,
-}
-
-impl InputTranscriptionKey {
-    fn new(item_id: String, content_index: u32) -> Self {
-        Self {
-            item_id,
-            content_index,
-        }
-    }
-}
-
-impl OutputTranscriptionKey {
-    fn new(item_id: String, output_index: u32, content_index: u32) -> Self {
-        Self {
-            item_id,
-            output_index,
-            content_index,
-        }
-    }
 }
 
 #[cfg(feature = "prompt-delay")]
@@ -491,8 +446,9 @@ impl Client {
                 },
             ) => {
                 if transcription.input {
-                    let key = InputTranscriptionKey::new(item_id, content_index);
-                    let text = self.transcription_state.apply_input_delta(key, delta);
+                    let text = self
+                        .transcription_state
+                        .apply_input_delta(item_id, content_index, delta);
                     output.text(false, text, None, None)?;
                 }
             }
@@ -506,7 +462,8 @@ impl Client {
             ) => {
                 if transcription.input
                     && let Some(text) = self.transcription_state.complete_input_transcription(
-                        InputTranscriptionKey::new(item_id, content_index),
+                        item_id,
+                        content_index,
                         transcript,
                     )
                 {
@@ -524,10 +481,9 @@ impl Client {
                 },
             ) => {
                 if transcription.output {
-                    let key = OutputTranscriptionKey::new(item_id, output_index, content_index);
                     let text = self
                         .transcription_state
-                        .apply_output_delta(response_id, key, delta);
+                        .apply_output_delta(response_id, item_id, output_index, content_index, delta);
                     output.text(false, text, None, Some(AI_AGENT_SPEAKER.into()))?;
                 }
             }
@@ -544,7 +500,9 @@ impl Client {
                 if transcription.output
                     && let Some(text) = self.transcription_state.complete_output_transcription(
                         response_id,
-                        OutputTranscriptionKey::new(item_id, output_index, content_index),
+                        item_id,
+                        output_index,
+                        content_index,
                         transcript,
                     )
                 {
@@ -741,81 +699,6 @@ impl Client {
         }
 
         Ok(())
-    }
-}
-
-impl TranscriptionState {
-    fn apply_input_delta(&mut self, key: InputTranscriptionKey, delta: String) -> String {
-        let entry = self.input_transcription_buffers.entry(key).or_default();
-        entry.push_str(&delta);
-        entry.clone()
-    }
-
-    fn complete_input_transcription(
-        &mut self,
-        key: InputTranscriptionKey,
-        transcript: String,
-    ) -> Option<String> {
-        let text = if transcript.is_empty() {
-            self.input_transcription_buffers
-                .remove(&key)
-                .unwrap_or_default()
-        } else {
-            self.input_transcription_buffers.remove(&key);
-            transcript
-        };
-
-        (!text.is_empty()).then_some(text)
-    }
-
-    fn apply_output_delta(
-        &mut self,
-        response_id: String,
-        key: OutputTranscriptionKey,
-        delta: String,
-    ) -> String {
-        self.output_transcription_responses.insert(response_id);
-        let entry = self.output_transcription_buffers.entry(key).or_default();
-        entry.push_str(&delta);
-        entry.clone()
-    }
-
-    fn complete_output_transcription(
-        &mut self,
-        response_id: String,
-        key: OutputTranscriptionKey,
-        transcript: String,
-    ) -> Option<String> {
-        self.output_transcription_responses.insert(response_id);
-        let text = if transcript.is_empty() {
-            self.output_transcription_buffers
-                .remove(&key)
-                .unwrap_or_default()
-        } else {
-            self.output_transcription_buffers.remove(&key);
-            transcript
-        };
-
-        (!text.is_empty()).then_some(text)
-    }
-
-    fn clear_output_response_tracking(&mut self, response_id: &str) {
-        self.output_transcription_responses.remove(response_id);
-    }
-
-    fn clear_item(&mut self, item_id: &str) {
-        self.input_transcription_buffers
-            .retain(|buffer_key, _| buffer_key.item_id != item_id);
-        self.output_transcription_buffers
-            .retain(|buffer_key, _| buffer_key.item_id != item_id);
-    }
-
-    fn clear_content_index(&mut self, item_id: String, content_index: u32) {
-        let key = InputTranscriptionKey::new(item_id.clone(), content_index);
-        self.input_transcription_buffers.remove(&key);
-        self.output_transcription_buffers.retain(|buffer_key, _| {
-            buffer_key.item_id != item_id || buffer_key.content_index != content_index
-        });
     }
 }
 

--- a/services/openai-dialog/src/client.rs
+++ b/services/openai-dialog/src/client.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 #[cfg(feature = "prompt-delay")]
 use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result, bail};
 use base64::prelude::*;
@@ -8,9 +8,7 @@ use futures::stream::{SplitSink, SplitStream};
 use futures::{SinkExt, StreamExt};
 use openai_api_rs::realtime::client_event::{self, ClientEvent};
 use openai_api_rs::realtime::server_event::{self, ServerEvent};
-use openai_api_rs::realtime::types::{
-    self, ItemContentType, ItemRole, ItemStatus, ItemType, OutputModality, ResponseStatus,
-};
+use openai_api_rs::realtime::types::{self, ItemStatus, ItemType, OutputModality, ResponseStatus};
 use tokio::{net::TcpStream, select};
 use tokio_tungstenite::tungstenite::{Bytes, protocol::Message};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
@@ -41,7 +39,41 @@ pub struct TranscriptionSettings {
 
 #[derive(Debug, Default)]
 struct TranscriptionState {
-    input_transcription_buffers: HashMap<(String, u32), String>,
+    input_transcription_buffers: HashMap<InputTranscriptionKey, String>,
+    output_transcription_buffers: HashMap<OutputTranscriptionKey, String>,
+    output_transcription_responses: HashSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct InputTranscriptionKey {
+    item_id: String,
+    content_index: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct OutputTranscriptionKey {
+    item_id: String,
+    output_index: u32,
+    content_index: u32,
+}
+
+impl InputTranscriptionKey {
+    fn new(item_id: String, content_index: u32) -> Self {
+        Self {
+            item_id,
+            content_index,
+        }
+    }
+}
+
+impl OutputTranscriptionKey {
+    fn new(item_id: String, output_index: u32, content_index: u32) -> Self {
+        Self {
+            item_id,
+            output_index,
+            content_index,
+        }
+    }
 }
 
 #[cfg(feature = "prompt-delay")]
@@ -420,12 +452,6 @@ impl Client {
         transcription: TranscriptionSettings,
     ) -> Result<()> {
         let event_for_log = match &event {
-            ServerEvent::ResponseAudioDelta(delta) => {
-                ServerEvent::ResponseAudioDelta(server_event::ResponseAudioDelta {
-                    delta: "[REMOVED]".to_string(),
-                    ..delta.clone()
-                })
-            }
             ServerEvent::ResponseOutputAudioDelta(delta) => {
                 ServerEvent::ResponseOutputAudioDelta(server_event::ResponseOutputAudioDelta {
                     delta: "[REMOVED]".to_string(),
@@ -444,16 +470,6 @@ impl Client {
 
                 #[cfg(not(feature = "prompt-delay"))]
                 self.handle_server_error(raw, &e)?;
-            }
-            ServerEvent::ResponseAudioDelta(audio_delta) => {
-                let decoded = BASE64_STANDARD.decode(audio_delta.delta)?;
-                let samples = audio::from_le_bytes(&decoded);
-                trace!("Sending {} samples", samples.len());
-                let frame = AudioFrame {
-                    format: output_format,
-                    samples,
-                };
-                output.audio_frame(frame)?;
             }
             ServerEvent::ResponseOutputAudioDelta(audio_delta) => {
                 let decoded = BASE64_STANDARD.decode(audio_delta.delta)?;
@@ -475,9 +491,8 @@ impl Client {
                 },
             ) => {
                 if transcription.input {
-                    let text =
-                        self.transcription_state
-                            .apply_input_delta(item_id, content_index, delta);
+                    let key = InputTranscriptionKey::new(item_id, content_index);
+                    let text = self.transcription_state.apply_input_delta(key, delta);
                     output.text(false, text, None, None)?;
                 }
             }
@@ -491,8 +506,45 @@ impl Client {
             ) => {
                 if transcription.input
                     && let Some(text) = self.transcription_state.complete_input_transcription(
-                        item_id,
-                        content_index,
+                        InputTranscriptionKey::new(item_id, content_index),
+                        transcript,
+                    )
+                {
+                    output.text(true, text, None, None)?;
+                }
+            }
+            ServerEvent::ResponseOutputAudioTranscriptDelta(
+                server_event::ResponseOutputAudioTranscriptDelta {
+                    response_id,
+                    item_id,
+                    output_index,
+                    content_index,
+                    delta,
+                    ..
+                },
+            ) => {
+                if transcription.output {
+                    let key = OutputTranscriptionKey::new(item_id, output_index, content_index);
+                    let text = self
+                        .transcription_state
+                        .apply_output_delta(response_id, key, delta);
+                    output.text(false, text, None, None)?;
+                }
+            }
+            ServerEvent::ResponseOutputAudioTranscriptDone(
+                server_event::ResponseOutputAudioTranscriptDone {
+                    response_id,
+                    item_id,
+                    output_index,
+                    content_index,
+                    transcript,
+                    ..
+                },
+            ) => {
+                if transcription.output
+                    && let Some(text) = self.transcription_state.complete_output_transcription(
+                        response_id,
+                        OutputTranscriptionKey::new(item_id, output_index, content_index),
                         transcript,
                     )
                 {
@@ -525,6 +577,7 @@ impl Client {
             ServerEvent::ResponseDone(server_event::ResponseDone {
                 response:
                     types::Response {
+                        id: response_id,
                         object,
                         status,
                         output: items,
@@ -533,16 +586,21 @@ impl Client {
                     },
                 ..
             }) if object == "realtime.response" => {
+                // Kept for potential rollback/debugging, but intentionally disabled.
+                // let output_transcript_events_seen = self
+                //     .transcription_state
+                //     .has_output_transcript_events_for_response(&response_id);
+
                 #[cfg(feature = "prompt-delay")]
                 let mut any_function_call_request = false;
                 for item in items {
-                    match (&status, &item.r#type, &item.status, &item.role) {
+                    debug!("Response Item: {item:?}");
+                    match (&status, &item.r#type, &item.status) {
                         (
                             // For now we process function calls only in the completed response.
                             ResponseStatus::Completed,
                             Some(ItemType::FunctionCall),
                             Some(ItemStatus::Completed),
-                            ..,
                         ) => {
                             let (Some(name), Some(call_id)) = (&item.name, &item.call_id) else {
                                 continue;
@@ -579,28 +637,38 @@ impl Client {
                                 any_function_call_request = true;
                             }
                         }
-                        (_, Some(types::ItemType::Message), _, Some(ItemRole::Assistant))
-                            if transcription.output =>
-                        {
-                            for transcript in item
-                                .content
-                                .into_iter()
-                                .flatten()
-                                .filter(|c| c.r#type == ItemContentType::Audio)
-                                .filter_map(|c| c.transcript)
-                            {
-                                // Even though we receive partial text (because of a turn, this is not a
-                                // classic non-final, because non-final text is always overwritten with
-                                // a more refined text later, this isn't)
-                                info!("output text: {transcript}");
-                                output.text(true, transcript, None, None)?;
-                            }
-                        }
+                        // Disabled fallback path: ignore transcript fields in `realtime.response`
+                        // and only finalize via `response.output_audio_transcript.done`.
+                        //
+                        // (_, Some(types::ItemType::Message), _, Some(ItemRole::Assistant))
+                        //     if transcription.output && !output_transcript_events_seen =>
+                        // {
+                        //     for transcript in item
+                        //         .content
+                        //         .into_iter()
+                        //         .flatten()
+                        //         .filter(|c| c.r#type == ItemContentType::OutputAudio)
+                        //         .filter_map(|c| c.transcript)
+                        //     {
+                        //         // Even though we receive partial text (because of a turn, this is not a
+                        //         // classic non-final, because non-final text is always overwritten with
+                        //         // a more refined text later, this isn't)
+                        //         info!("Output text: {transcript}");
+                        //         output.text(true, transcript, None, None)?;
+                        //     }
+                        // }
                         _ => {
-                            debug!("Unprocessed item: {item:?}")
+                            trace!("Unprocessed response item: {item:?}")
                         }
                     }
+
+                    if let Some(item_id) = item.id.as_deref() {
+                        self.transcription_state.clear_item(item_id);
+                    }
                 }
+
+                self.transcription_state
+                    .clear_output_response_tracking(&response_id);
 
                 if let Some(usage) = usage {
                     let input_details = &usage.input_token_details;
@@ -677,22 +745,17 @@ impl Client {
 }
 
 impl TranscriptionState {
-    fn apply_input_delta(&mut self, item_id: String, content_index: u32, delta: String) -> String {
-        let entry = self
-            .input_transcription_buffers
-            .entry((item_id, content_index))
-            .or_default();
+    fn apply_input_delta(&mut self, key: InputTranscriptionKey, delta: String) -> String {
+        let entry = self.input_transcription_buffers.entry(key).or_default();
         entry.push_str(&delta);
         entry.clone()
     }
 
     fn complete_input_transcription(
         &mut self,
-        item_id: String,
-        content_index: u32,
+        key: InputTranscriptionKey,
         transcript: String,
     ) -> Option<String> {
-        let key = (item_id, content_index);
         let text = if transcript.is_empty() {
             self.input_transcription_buffers
                 .remove(&key)
@@ -705,14 +768,54 @@ impl TranscriptionState {
         (!text.is_empty()).then_some(text)
     }
 
+    fn apply_output_delta(
+        &mut self,
+        response_id: String,
+        key: OutputTranscriptionKey,
+        delta: String,
+    ) -> String {
+        self.output_transcription_responses.insert(response_id);
+        let entry = self.output_transcription_buffers.entry(key).or_default();
+        entry.push_str(&delta);
+        entry.clone()
+    }
+
+    fn complete_output_transcription(
+        &mut self,
+        response_id: String,
+        key: OutputTranscriptionKey,
+        transcript: String,
+    ) -> Option<String> {
+        self.output_transcription_responses.insert(response_id);
+        let text = if transcript.is_empty() {
+            self.output_transcription_buffers
+                .remove(&key)
+                .unwrap_or_default()
+        } else {
+            self.output_transcription_buffers.remove(&key);
+            transcript
+        };
+
+        (!text.is_empty()).then_some(text)
+    }
+
+    fn clear_output_response_tracking(&mut self, response_id: &str) {
+        self.output_transcription_responses.remove(response_id);
+    }
+
     fn clear_item(&mut self, item_id: &str) {
         self.input_transcription_buffers
-            .retain(|(buffer_item_id, _), _| buffer_item_id != item_id);
+            .retain(|buffer_key, _| buffer_key.item_id != item_id);
+        self.output_transcription_buffers
+            .retain(|buffer_key, _| buffer_key.item_id != item_id);
     }
 
     fn clear_content_index(&mut self, item_id: String, content_index: u32) {
-        self.input_transcription_buffers
-            .remove(&(item_id, content_index));
+        let key = InputTranscriptionKey::new(item_id.clone(), content_index);
+        self.input_transcription_buffers.remove(&key);
+        self.output_transcription_buffers.retain(|buffer_key, _| {
+            buffer_key.item_id != item_id || buffer_key.content_index != content_index
+        });
     }
 }
 

--- a/services/openai-dialog/src/client.rs
+++ b/services/openai-dialog/src/client.rs
@@ -18,8 +18,8 @@ use uuid::Uuid;
 
 use crate::{Params, ServiceInputEvent, ServiceOutputEvent};
 use context_switch_core::{
-    AudioFormat, AudioFrame, BillingRecord, BillingSchedule, ConversationInput, ConversationOutput,
-    Input, OutputPath, audio,
+    AI_AGENT_SPEAKER, AudioFormat, AudioFrame, BillingRecord, BillingSchedule,
+    ConversationInput, ConversationOutput, Input, OutputPath, audio,
 };
 
 pub struct Client {
@@ -528,7 +528,7 @@ impl Client {
                     let text = self
                         .transcription_state
                         .apply_output_delta(response_id, key, delta);
-                    output.text(false, text, None, None)?;
+                    output.text(false, text, None, Some(AI_AGENT_SPEAKER.into()))?;
                 }
             }
             ServerEvent::ResponseOutputAudioTranscriptDone(
@@ -548,7 +548,7 @@ impl Client {
                         transcript,
                     )
                 {
-                    output.text(true, text, None, None)?;
+                    output.text(true, text, None, Some(AI_AGENT_SPEAKER.into()))?;
                 }
             }
             ServerEvent::ConversationItemDeleted(server_event::ConversationItemDeleted {

--- a/services/openai-dialog/src/client.rs
+++ b/services/openai-dialog/src/client.rs
@@ -559,7 +559,7 @@ impl Client {
                 #[cfg(feature = "prompt-delay")]
                 let mut any_function_call_request = false;
                 for item in items {
-                    debug!("Response Item: {item:?}");
+                    trace!("Response Item: {item:?}");
                     match (&status, &item.r#type, &item.status) {
                         (
                             // For now we process function calls only in the completed response.

--- a/services/openai-dialog/src/client.rs
+++ b/services/openai-dialog/src/client.rs
@@ -18,8 +18,8 @@ use uuid::Uuid;
 use crate::transcription::{TranscriptionSettings, TranscriptionState};
 use crate::{Params, ServiceInputEvent, ServiceOutputEvent};
 use context_switch_core::{
-    AI_AGENT_SPEAKER, AudioFormat, AudioFrame, BillingRecord, BillingSchedule,
-    ConversationInput, ConversationOutput, Input, OutputPath, audio,
+    AI_AGENT_SPEAKER, AudioFormat, AudioFrame, BillingRecord, BillingSchedule, ConversationInput,
+    ConversationOutput, Input, OutputPath, audio,
 };
 
 pub struct Client {
@@ -446,9 +446,9 @@ impl Client {
                 },
             ) => {
                 if transcription.input {
-                    let text = self
-                        .transcription_state
-                        .apply_input_delta(item_id, content_index, delta);
+                    let text =
+                        self.transcription_state
+                            .apply_input_delta(item_id, content_index, delta);
                     output.text(false, text, None, None)?;
                 }
             }
@@ -470,6 +470,7 @@ impl Client {
                     output.text(true, text, None, None)?;
                 }
             }
+            #[cfg(feature = "interim-output-text-events")]
             ServerEvent::ResponseOutputAudioTranscriptDelta(
                 server_event::ResponseOutputAudioTranscriptDelta {
                     response_id,
@@ -481,12 +482,18 @@ impl Client {
                 },
             ) => {
                 if transcription.output {
-                    let text = self
-                        .transcription_state
-                        .apply_output_delta(response_id, item_id, output_index, content_index, delta);
+                    let text = self.transcription_state.apply_output_delta(
+                        response_id,
+                        item_id,
+                        output_index,
+                        content_index,
+                        delta,
+                    );
                     output.text(false, text, None, Some(AI_AGENT_SPEAKER.into()))?;
                 }
             }
+            #[cfg(not(feature = "interim-output-text-events"))]
+            ServerEvent::ResponseOutputAudioTranscriptDelta(..) => {}
             ServerEvent::ResponseOutputAudioTranscriptDone(
                 server_event::ResponseOutputAudioTranscriptDone {
                     response_id,

--- a/services/openai-dialog/src/client.rs
+++ b/services/openai-dialog/src/client.rs
@@ -18,8 +18,8 @@ use uuid::Uuid;
 use crate::transcription::{TranscriptionSettings, TranscriptionState};
 use crate::{Params, ServiceInputEvent, ServiceOutputEvent};
 use context_switch_core::{
-    AI_AGENT_SPEAKER, AudioFormat, AudioFrame, BillingRecord, BillingSchedule, ConversationInput,
-    ConversationOutput, Input, OutputPath, audio,
+    AI_ASSISTANT_SPEAKER, AudioFormat, AudioFrame, BillingRecord, BillingSchedule,
+    ConversationInput, ConversationOutput, Input, OutputPath, audio,
 };
 
 pub struct Client {
@@ -487,7 +487,7 @@ impl Client {
                         content_index,
                         delta,
                     );
-                    output.text(false, text, None, Some(AI_AGENT_SPEAKER.into()))?;
+                    output.text(false, text, None, Some(AI_ASSISTANT_SPEAKER.into()))?;
                 }
             }
             ServerEvent::ResponseOutputAudioTranscriptDone(
@@ -508,7 +508,7 @@ impl Client {
                         transcript,
                     )
                 {
-                    output.text(true, text, None, Some(AI_AGENT_SPEAKER.into()))?;
+                    output.text(true, text, None, Some(AI_ASSISTANT_SPEAKER.into()))?;
                 }
             }
             ServerEvent::ConversationItemDeleted(server_event::ConversationItemDeleted {

--- a/services/openai-dialog/src/client.rs
+++ b/services/openai-dialog/src/client.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 #[cfg(feature = "prompt-delay")]
 use std::collections::VecDeque;
 
@@ -11,10 +12,8 @@ use openai_api_rs::realtime::types::{
     self, ItemContentType, ItemRole, ItemStatus, ItemType, OutputModality, ResponseStatus,
 };
 use tokio::{net::TcpStream, select};
-use tokio_tungstenite::{
-    MaybeTlsStream, WebSocketStream,
-    tungstenite::{Bytes, protocol::Message},
-};
+use tokio_tungstenite::tungstenite::{Bytes, protocol::Message};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 use tracing::{debug, info, trace, warn};
 #[cfg(feature = "prompt-delay")]
 use uuid::Uuid;
@@ -28,9 +27,21 @@ use context_switch_core::{
 pub struct Client {
     read: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
     write: SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>,
+    transcription_state: TranscriptionState,
 
     #[cfg(feature = "prompt-delay")]
     prompt_coordinator: PromptCoordinator,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct TranscriptionSettings {
+    pub input: bool,
+    pub output: bool,
+}
+
+#[derive(Debug, Default)]
+struct TranscriptionState {
+    input_transcription_buffers: HashMap<(String, u32), String>,
 }
 
 #[cfg(feature = "prompt-delay")]
@@ -56,6 +67,7 @@ impl Client {
         Self {
             read,
             write,
+            transcription_state: TranscriptionState::default(),
             #[cfg(feature = "prompt-delay")]
             prompt_coordinator: PromptCoordinator::new(),
         }
@@ -67,7 +79,7 @@ impl Client {
         input_format: AudioFormat,
         output_format: AudioFormat,
         params: Params,
-        output_transcription: bool,
+        transcription: TranscriptionSettings,
         mut input: ConversationInput,
         output: ConversationOutput,
     ) -> Result<()> {
@@ -98,6 +110,8 @@ impl Client {
         {
             let mut send_update = false;
             let mut session = types::RealtimeSession::default();
+            let mut audio_input = None;
+            let mut audio_output = None;
 
             if let Some(instructions) = params.instructions {
                 session.instructions = Some(instructions);
@@ -105,15 +119,33 @@ impl Client {
             };
 
             if let Some(voice) = params.voice {
-                session.audio = Some(types::AudioConfig {
-                    input: None,
-                    output: Some(types::AudioOutput {
-                        format: None,
-                        speed: 1.0,
-                        voice: Some(voice),
-                    }),
+                audio_output = Some(types::AudioOutput {
+                    format: None,
+                    speed: 1.0,
+                    voice: Some(voice),
                 });
                 send_update = true;
+            }
+
+            if transcription.input {
+                audio_input = Some(types::AudioInput {
+                    format: None,
+                    noise_reduction: None,
+                    transcription: Some(types::TranscriptionConfig {
+                        language: None,
+                        model: "gpt-realtime-whisper".to_string(),
+                        prompt: None,
+                    }),
+                    turn_detection: None,
+                });
+                send_update = true;
+            }
+
+            if audio_input.is_some() || audio_output.is_some() {
+                session.audio = Some(types::AudioConfig {
+                    input: audio_input,
+                    output: audio_output,
+                });
             }
 
             if !params.tools.is_empty() {
@@ -152,7 +184,7 @@ impl Client {
                 message = self.read.next() => {
                     match message {
                         Some(Ok(message)) => {
-                            match self.process_message(message, output_format, &output, &params.model, output_transcription).await? {
+                            match self.process_message(message, output_format, &output, &params.model, transcription).await? {
                                 FlowControl::End => { break; }
                                 FlowControl::PongAndContinue(payload) => {
                                     self.write.send(Message::Pong(payload)).await?;
@@ -348,7 +380,7 @@ impl Client {
         output_format: AudioFormat,
         output: &ConversationOutput,
         billing_scope: &str,
-        output_transcription: bool,
+        transcription: TranscriptionSettings,
     ) -> Result<FlowControl> {
         match message {
             Message::Text(str) => {
@@ -361,7 +393,7 @@ impl Client {
                     output,
                     output_format,
                     billing_scope,
-                    output_transcription,
+                    transcription,
                 )
                 .await?;
             }
@@ -385,7 +417,7 @@ impl Client {
         output: &ConversationOutput,
         output_format: AudioFormat,
         billing_scope: &str,
-        output_transcription: bool,
+        transcription: TranscriptionSettings,
     ) -> Result<()> {
         let event_for_log = match &event {
             ServerEvent::ResponseAudioDelta(delta) => {
@@ -434,6 +466,53 @@ impl Client {
                 output.audio_frame(frame)?;
             }
             ServerEvent::InputAudioBufferSpeechStarted(_) => output.clear_audio()?,
+            ServerEvent::ConversationItemInputAudioTranscriptionDelta(
+                server_event::ConversationItemInputAudioTranscriptionDelta {
+                    item_id,
+                    content_index,
+                    delta,
+                    ..
+                },
+            ) => {
+                if transcription.input {
+                    let text =
+                        self.transcription_state
+                            .apply_input_delta(item_id, content_index, delta);
+                    output.text(false, text, None, None)?;
+                }
+            }
+            ServerEvent::ConversationItemInputAudioTranscriptionCompleted(
+                server_event::ConversationItemInputAudioTranscriptionCompleted {
+                    item_id,
+                    content_index,
+                    transcript,
+                    ..
+                },
+            ) => {
+                if transcription.input
+                    && let Some(text) = self.transcription_state.complete_input_transcription(
+                        item_id,
+                        content_index,
+                        transcript,
+                    )
+                {
+                    output.text(true, text, None, None)?;
+                }
+            }
+            ServerEvent::ConversationItemDeleted(server_event::ConversationItemDeleted {
+                item_id,
+                ..
+            }) => {
+                self.transcription_state.clear_item(&item_id);
+            }
+            ServerEvent::ConversationItemTruncated(server_event::ConversationItemTruncated {
+                item_id,
+                content_index,
+                ..
+            }) => {
+                self.transcription_state
+                    .clear_content_index(item_id, content_index);
+            }
             ServerEvent::ResponseCreated(server_event::ResponseCreated {
                 response: types::Response { object, .. },
                 ..
@@ -501,7 +580,7 @@ impl Client {
                             }
                         }
                         (_, Some(types::ItemType::Message), _, Some(ItemRole::Assistant))
-                            if output_transcription =>
+                            if transcription.output =>
                         {
                             for transcript in item
                                 .content
@@ -594,6 +673,46 @@ impl Client {
         }
 
         Ok(())
+    }
+}
+
+impl TranscriptionState {
+    fn apply_input_delta(&mut self, item_id: String, content_index: u32, delta: String) -> String {
+        let entry = self
+            .input_transcription_buffers
+            .entry((item_id, content_index))
+            .or_default();
+        entry.push_str(&delta);
+        entry.clone()
+    }
+
+    fn complete_input_transcription(
+        &mut self,
+        item_id: String,
+        content_index: u32,
+        transcript: String,
+    ) -> Option<String> {
+        let key = (item_id, content_index);
+        let text = if transcript.is_empty() {
+            self.input_transcription_buffers
+                .remove(&key)
+                .unwrap_or_default()
+        } else {
+            self.input_transcription_buffers.remove(&key);
+            transcript
+        };
+
+        (!text.is_empty()).then_some(text)
+    }
+
+    fn clear_item(&mut self, item_id: &str) {
+        self.input_transcription_buffers
+            .retain(|(buffer_item_id, _), _| buffer_item_id != item_id);
+    }
+
+    fn clear_content_index(&mut self, item_id: String, content_index: u32) {
+        self.input_transcription_buffers
+            .remove(&(item_id, content_index));
     }
 }
 

--- a/services/openai-dialog/src/lib.rs
+++ b/services/openai-dialog/src/lib.rs
@@ -10,11 +10,12 @@ use context_switch_core::{Conversation, Service};
 
 mod client;
 mod host;
+mod transcription;
 mod types;
 
 pub use client::Client;
-use client::TranscriptionSettings;
 pub use host::{Host, Protocol};
+use transcription::TranscriptionSettings;
 pub use types::{Params, ServiceInputEvent, ServiceOutputEvent};
 
 use host::resolve_protocol;

--- a/services/openai-dialog/src/lib.rs
+++ b/services/openai-dialog/src/lib.rs
@@ -32,12 +32,14 @@ impl Service for OpenAIDialog {
         let output_format = conversation.require_one_audio_output()?;
         // Architecture: this can be derived further down.
         let has_text_output = conversation.has_one_text_output()?;
-        let output_transcription = has_text_output;
+        let output_transcription = params.output_audio_transcription && has_text_output;
         let input_transcription = params.input_audio_transcription && has_text_output;
-        if !has_text_output && (params.input_audio_transcription || output_transcription) {
+        if !has_text_output
+            && (params.input_audio_transcription || params.output_audio_transcription)
+        {
             warn!(
                 input_audio_transcription = params.input_audio_transcription,
-                output_transcription,
+                output_audio_transcription = params.output_audio_transcription,
                 "Transcription requested without text output modality; transcription output will be suppressed"
             );
         }

--- a/services/openai-dialog/src/lib.rs
+++ b/services/openai-dialog/src/lib.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{Result, bail};
 use async_trait::async_trait;
-use tracing::info;
+use tracing::{info, warn};
 
 use context_switch_core::{Conversation, Service};
 
@@ -13,6 +13,7 @@ mod host;
 mod types;
 
 pub use client::Client;
+use client::TranscriptionSettings;
 pub use host::{Host, Protocol};
 pub use types::{Params, ServiceInputEvent, ServiceOutputEvent};
 
@@ -30,7 +31,16 @@ impl Service for OpenAIDialog {
         let input_format = conversation.require_audio_input()?;
         let output_format = conversation.require_one_audio_output()?;
         // Architecture: this can be derived further down.
-        let output_transcription = conversation.has_one_text_output()?;
+        let has_text_output = conversation.has_one_text_output()?;
+        let output_transcription = has_text_output;
+        let input_transcription = params.input_audio_transcription && has_text_output;
+        if !has_text_output && (params.input_audio_transcription || output_transcription) {
+            warn!(
+                input_audio_transcription = params.input_audio_transcription,
+                output_transcription,
+                "Transcription requested without text output modality; transcription output will be suppressed"
+            );
+        }
         if input_format != output_format {
             bail!("Input and output audio formats must match for OpenAI dialog service");
         }
@@ -54,7 +64,10 @@ impl Service for OpenAIDialog {
                 input_format,
                 output_format,
                 params,
-                output_transcription,
+                TranscriptionSettings {
+                    input: input_transcription,
+                    output: output_transcription,
+                },
                 input,
                 output,
             )

--- a/services/openai-dialog/src/transcription.rs
+++ b/services/openai-dialog/src/transcription.rs
@@ -1,0 +1,135 @@
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, Copy)]
+pub struct TranscriptionSettings {
+    pub input: bool,
+    pub output: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct TranscriptionState {
+    input_transcription_buffers: HashMap<InputTranscriptionKey, String>,
+    output_transcription_buffers: HashMap<OutputTranscriptionKey, String>,
+    output_transcription_responses: HashSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct InputTranscriptionKey {
+    item_id: String,
+    content_index: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct OutputTranscriptionKey {
+    item_id: String,
+    output_index: u32,
+    content_index: u32,
+}
+
+impl InputTranscriptionKey {
+    fn new(item_id: String, content_index: u32) -> Self {
+        Self {
+            item_id,
+            content_index,
+        }
+    }
+}
+
+impl OutputTranscriptionKey {
+    fn new(item_id: String, output_index: u32, content_index: u32) -> Self {
+        Self {
+            item_id,
+            output_index,
+            content_index,
+        }
+    }
+}
+
+impl TranscriptionState {
+    pub fn apply_input_delta(
+        &mut self,
+        item_id: String,
+        content_index: u32,
+        delta: String,
+    ) -> String {
+        let key = InputTranscriptionKey::new(item_id, content_index);
+        let entry = self.input_transcription_buffers.entry(key).or_default();
+        entry.push_str(&delta);
+        entry.clone()
+    }
+
+    pub fn complete_input_transcription(
+        &mut self,
+        item_id: String,
+        content_index: u32,
+        transcript: String,
+    ) -> Option<String> {
+        let key = InputTranscriptionKey::new(item_id, content_index);
+        let text = if transcript.is_empty() {
+            self.input_transcription_buffers
+                .remove(&key)
+                .unwrap_or_default()
+        } else {
+            self.input_transcription_buffers.remove(&key);
+            transcript
+        };
+
+        (!text.is_empty()).then_some(text)
+    }
+
+    pub fn apply_output_delta(
+        &mut self,
+        response_id: String,
+        item_id: String,
+        output_index: u32,
+        content_index: u32,
+        delta: String,
+    ) -> String {
+        self.output_transcription_responses.insert(response_id);
+        let key = OutputTranscriptionKey::new(item_id, output_index, content_index);
+        let entry = self.output_transcription_buffers.entry(key).or_default();
+        entry.push_str(&delta);
+        entry.clone()
+    }
+
+    pub fn complete_output_transcription(
+        &mut self,
+        response_id: String,
+        item_id: String,
+        output_index: u32,
+        content_index: u32,
+        transcript: String,
+    ) -> Option<String> {
+        self.output_transcription_responses.insert(response_id);
+        let key = OutputTranscriptionKey::new(item_id, output_index, content_index);
+        let text = if transcript.is_empty() {
+            self.output_transcription_buffers
+                .remove(&key)
+                .unwrap_or_default()
+        } else {
+            self.output_transcription_buffers.remove(&key);
+            transcript
+        };
+
+        (!text.is_empty()).then_some(text)
+    }
+
+    pub fn clear_output_response_tracking(&mut self, response_id: &str) {
+        self.output_transcription_responses.remove(response_id);
+    }
+
+    pub fn clear_item(&mut self, item_id: &str) {
+        self.input_transcription_buffers
+            .retain(|buffer_key, _| buffer_key.item_id != item_id);
+        self.output_transcription_buffers
+            .retain(|buffer_key, _| buffer_key.item_id != item_id);
+    }
+
+    pub fn clear_content_index(&mut self, item_id: String, content_index: u32) {
+        let key = InputTranscriptionKey::new(item_id.clone(), content_index);
+        self.input_transcription_buffers.remove(&key);
+        self.output_transcription_buffers.retain(|buffer_key, _| {
+            buffer_key.item_id != item_id || buffer_key.content_index != content_index
+        });
+    }
+}

--- a/services/openai-dialog/src/transcription.rs
+++ b/services/openai-dialog/src/transcription.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use tracing::warn;
 
 #[derive(Debug, Clone, Copy)]
 pub struct TranscriptionSettings {
@@ -77,6 +78,7 @@ impl TranscriptionState {
         (!text.is_empty()).then_some(text)
     }
 
+    #[cfg(feature = "interim-output-text-events")]
     pub fn apply_output_delta(
         &mut self,
         response_id: String,
@@ -101,17 +103,20 @@ impl TranscriptionState {
         transcript: String,
     ) -> Option<String> {
         self.output_transcription_responses.insert(response_id);
-        let key = OutputTranscriptionKey::new(item_id, output_index, content_index);
-        let text = if transcript.is_empty() {
-            self.output_transcription_buffers
-                .remove(&key)
-                .unwrap_or_default()
-        } else {
+        let key = OutputTranscriptionKey::new(item_id.clone(), output_index, content_index);
+        if transcript.is_empty() {
             self.output_transcription_buffers.remove(&key);
-            transcript
-        };
+            warn!(
+                item_id,
+                output_index,
+                content_index,
+                "Received empty output transcript completion; ignoring"
+            );
+            return None;
+        }
 
-        (!text.is_empty()).then_some(text)
+        self.output_transcription_buffers.remove(&key);
+        Some(transcript)
     }
 
     pub fn clear_output_response_tracking(&mut self, response_id: &str) {

--- a/services/openai-dialog/src/transcription.rs
+++ b/services/openai-dialog/src/transcription.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use tracing::warn;
 
 #[derive(Debug, Clone, Copy)]
@@ -11,7 +11,6 @@ pub struct TranscriptionSettings {
 pub struct TranscriptionState {
     input_transcription_buffers: HashMap<InputTranscriptionKey, String>,
     output_transcription_buffers: HashMap<OutputTranscriptionKey, String>,
-    output_transcription_responses: HashSet<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -80,13 +79,11 @@ impl TranscriptionState {
 
     pub fn apply_output_delta(
         &mut self,
-        response_id: String,
         item_id: String,
         output_index: u32,
         content_index: u32,
         delta: String,
     ) -> String {
-        self.output_transcription_responses.insert(response_id);
         let key = OutputTranscriptionKey::new(item_id, output_index, content_index);
         let entry = self.output_transcription_buffers.entry(key).or_default();
         entry.push_str(&delta);
@@ -95,13 +92,11 @@ impl TranscriptionState {
 
     pub fn complete_output_transcription(
         &mut self,
-        response_id: String,
         item_id: String,
         output_index: u32,
         content_index: u32,
         transcript: String,
     ) -> Option<String> {
-        self.output_transcription_responses.insert(response_id);
         let key = OutputTranscriptionKey::new(item_id.clone(), output_index, content_index);
         if transcript.is_empty() {
             self.output_transcription_buffers.remove(&key);
@@ -116,10 +111,6 @@ impl TranscriptionState {
 
         self.output_transcription_buffers.remove(&key);
         Some(transcript)
-    }
-
-    pub fn clear_output_response_tracking(&mut self, response_id: &str) {
-        self.output_transcription_responses.remove(response_id);
     }
 
     pub fn clear_item(&mut self, item_id: &str) {

--- a/services/openai-dialog/src/transcription.rs
+++ b/services/openai-dialog/src/transcription.rs
@@ -78,7 +78,6 @@ impl TranscriptionState {
         (!text.is_empty()).then_some(text)
     }
 
-    #[cfg(feature = "interim-output-text-events")]
     pub fn apply_output_delta(
         &mut self,
         response_id: String,

--- a/services/openai-dialog/src/types.rs
+++ b/services/openai-dialog/src/types.rs
@@ -11,6 +11,8 @@ pub struct Params {
     pub instructions: Option<String>,
     pub voice: Option<RealtimeVoice>,
     #[serde(default)]
+    pub input_audio_transcription: bool,
+    #[serde(default)]
     pub tools: Vec<types::ToolDefinition>,
     pub(crate) tool_choice: Option<ToolChoice>,
 }
@@ -24,6 +26,7 @@ impl Params {
             host: None,
             instructions: None,
             voice: None,
+            input_audio_transcription: false,
             tools: vec![],
             tool_choice: None,
         }

--- a/services/openai-dialog/src/types.rs
+++ b/services/openai-dialog/src/types.rs
@@ -13,6 +13,8 @@ pub struct Params {
     #[serde(default)]
     pub input_audio_transcription: bool,
     #[serde(default)]
+    pub output_audio_transcription: bool,
+    #[serde(default)]
     pub tools: Vec<types::ToolDefinition>,
     pub(crate) tool_choice: Option<ToolChoice>,
 }
@@ -27,6 +29,7 @@ impl Params {
             instructions: None,
             voice: None,
             input_audio_transcription: false,
+            output_audio_transcription: false,
             tools: vec![],
             tool_choice: None,
         }


### PR DESCRIPTION
In google-dialog is seems that the current 3.1 live preview model sends transcription events even though they were never enabled. We want this to be consistent with the flags provided.

- [x] Only send text events when the transcription is actually subscribed.
- [x] Fixed problem that when interrupted the output buffer is not sent to the client as final transcription text.