### PR TITLE
Use an explicit connector for Azure backend services.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.4.1"
+version = "3.4.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pragmatrix/context-switch"

--- a/services/azure/Cargo.toml
+++ b/services/azure/Cargo.toml
@@ -7,12 +7,9 @@ edition.workspace = true
 context-switch-core = { workspace = true }
 
 azure-speech = { workspace = true, features = [
-	# Use the operating system's trust store for Azure TLS connections.
+	# Enable `Connector::NativeTls`, which drives the explicit connector below via the
+	# operating system's trust store. `tokio-native-tls` alone only constructs it.
 	"tws-native-tls",
-	# Generate WebSocket client handshake keys.
-	"tws-rand",
-	# Validate the WebSocket server handshake response.
-	"tws-smol-sha1",
 ] }
 tokio-native-tls = "0.3.1"
 

--- a/services/azure/Cargo.toml
+++ b/services/azure/Cargo.toml
@@ -6,7 +6,15 @@ edition.workspace = true
 [dependencies]
 context-switch-core = { workspace = true }
 
-azure-speech = { workspace = true }
+azure-speech = { workspace = true, features = [
+	# Use the operating system's trust store for Azure TLS connections.
+	"tws-native-tls",
+	# Generate WebSocket client handshake keys.
+	"tws-rand",
+	# Validate the WebSocket server handshake response.
+	"tws-smol-sha1",
+] }
+tokio-native-tls = "0.3.1"
 
 tracing = { workspace = true }
 anyhow = { workspace = true }

--- a/services/azure/src/lib.rs
+++ b/services/azure/src/lib.rs
@@ -1,6 +1,7 @@
-use std::{future::Future, time::Duration};
+use std::{future::Future, sync::OnceLock, time::Duration};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
+use azure_speech::Connector;
 use tokio::time::timeout;
 
 mod host;
@@ -23,4 +24,18 @@ async fn connect_with_timeout<T>(connection: impl Future<Output = T>) -> Result<
     timeout(CONNECT_TIMEOUT, connection)
         .await
         .context("Azure connection timed out")
+}
+
+fn native_tls_connector() -> Result<&'static Connector> {
+    static CONNECTOR: OnceLock<Result<Connector, String>> = OnceLock::new();
+
+    match CONNECTOR.get_or_init(|| {
+        tokio_native_tls::native_tls::TlsConnector::new()
+            .map(tokio_native_tls::TlsConnector::from)
+            .map(Connector::NativeTls)
+            .map_err(|error| error.to_string())
+    }) {
+        Ok(connector) => Ok(connector),
+        Err(error) => bail!("Failed to create native TLS connector: {error}"),
+    }
 }

--- a/services/azure/src/lib.rs
+++ b/services/azure/src/lib.rs
@@ -1,4 +1,6 @@
-use std::{future::Future, sync::OnceLock, time::Duration};
+use std::future::Future;
+use std::sync::OnceLock;
+use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use azure_speech::Connector;

--- a/services/azure/src/synthesize.rs
+++ b/services/azure/src/synthesize.rs
@@ -14,7 +14,7 @@ use context_switch_core::{
     AudioFrame, BillingRecord, BillingSchedule, Conversation, Input, Service,
 };
 
-use crate::{Host, connect_with_timeout};
+use crate::{Host, connect_with_timeout, native_tls_connector};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -64,8 +64,12 @@ impl Service for AzureSynthesize {
             .enable_session_end()
             .with_audio_format(azure_audio_format);
 
-        let client =
-            connect_with_timeout(synthesizer::Client::connect(host.auth.clone(), config)).await??;
+        let client = connect_with_timeout(synthesizer::Client::connect(
+            host.auth.clone(),
+            config,
+            native_tls_connector()?,
+        ))
+        .await??;
 
         let language = params.language;
         let (mut input, output) = conversation.start()?;

--- a/services/azure/src/transcribe.rs
+++ b/services/azure/src/transcribe.rs
@@ -13,7 +13,7 @@ use context_switch_core::{
     speech_gate::make_speech_gate_processor_soft_rms,
 };
 
-use crate::{Host, connect_with_timeout};
+use crate::{Host, connect_with_timeout, native_tls_connector};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -90,8 +90,12 @@ impl Service for AzureTranscribe {
         }
         .set_output_format(recognizer::OutputFormat::Detailed);
 
-        let client =
-            connect_with_timeout(recognizer::Client::connect(host.auth.clone(), config)).await??;
+        let client = connect_with_timeout(recognizer::Client::connect(
+            host.auth.clone(),
+            config,
+            native_tls_connector()?,
+        ))
+        .await??;
 
         let (mut input, output) = conversation.start()?;
 

--- a/services/azure/src/translate.rs
+++ b/services/azure/src/translate.rs
@@ -6,7 +6,7 @@ use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error};
 
-use crate::{Host, connect_with_timeout};
+use crate::{Host, connect_with_timeout, native_tls_connector};
 use context_switch_core::{
     AudioFormat, AudioFrame, BillingRecord, BillingSchedule, Conversation, Input, OutputModality,
     OutputPath, Service,
@@ -74,8 +74,12 @@ impl Service for AzureTranslate {
             }
         };
 
-        let client =
-            connect_with_timeout(translator::Client::connect(host.auth.clone(), config)).await??;
+        let client = connect_with_timeout(translator::Client::connect(
+            host.auth.clone(),
+            config,
+            native_tls_connector()?,
+        ))
+        .await??;
 
         let (mut input, output) = conversation.start()?;
 


### PR DESCRIPTION
With the update of tokio-websockets the Azure connection attempts failed with:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
```

The solution to that is to make the crypto provider / connector explicit.
