### PR TITLE
Properly handle the Azure Recognizer shutdown after audio ended.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.5.1"
+version = "3.5.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/pragmatrix/context-switch"
@@ -68,7 +68,7 @@ hound = { workspace = true }
 chrono = { workspace = true }
 
 [dev-dependencies]
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 context-switch-core = { workspace = true }
 
 dotenvy = { workspace = true }

--- a/services/azure/src/transcribe.rs
+++ b/services/azure/src/transcribe.rs
@@ -3,7 +3,7 @@ use async_stream::stream;
 use async_trait::async_trait;
 use futures::StreamExt;
 use serde::Deserialize;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 use azure_speech::recognizer::{self, Event};
 
@@ -90,12 +90,14 @@ impl Service for AzureTranscribe {
         }
         .set_output_format(recognizer::OutputFormat::Detailed);
 
+        debug!("Connecting Azure recognizer");
         let client = connect_with_timeout(recognizer::Client::connect(
             host.auth.clone(),
             config,
             native_tls_connector()?,
         ))
         .await??;
+        debug!("Azure recognizer connected");
 
         let (mut input, output) = conversation.start()?;
 
@@ -130,6 +132,7 @@ impl Service for AzureTranscribe {
                         error!("Internal error: Failed to output billing records: {e}");
                     }
                 }
+                debug!("Azure recognizer audio input ended");
             }
         };
 
@@ -143,7 +146,10 @@ impl Service for AzureTranscribe {
             .await?;
 
         while let Some(event) = stream.next().await {
-            match event? {
+            let event = event?;
+            trace!(?event, "Azure recognizer event");
+
+            match event {
                 Event::SessionStarted(_) | Event::SessionEnded(_) => {}
                 // StartDetected and EndDetected seem to be received only once per session. They are
                 // not usable for turn detection.

--- a/services/azure/src/transcribe.rs
+++ b/services/azure/src/transcribe.rs
@@ -147,7 +147,7 @@ impl Service for AzureTranscribe {
 
         while let Some(event) = stream.next().await {
             let event = event?;
-            trace!(?event, "Azure recognizer event");
+            trace!(event = ?std::mem::discriminant(&event), "Azure recognizer event");
 
             match event {
                 Event::SessionStarted(_) | Event::SessionEnded(_) => {}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,12 +13,11 @@ use crate::{
     Registry, ServerEvent, registry,
 };
 
-// Azure does not finish its recognition stream after ContextSwitch closes the input on Stop.
-// ContextSwitch therefore waits for its three-second shutdown grace period, logs the timeout,
-// and then emits Stopped. Late transcription output cannot be delivered during that period.
+// Regression: Azure recognizer should end its event stream promptly after ContextSwitch stops audio input.
+// This test ensures a Stop results in a timely `ServerEvent::Stopped` (no lingering stream/session restart).
 #[tokio::test]
 #[ignore = "requires Azure credentials and runs for about 8 seconds"]
-async fn azure_transcribe_logs_graceful_shutdown_timeout_after_stop() -> Result<()> {
+async fn azure_transcribe_stops_promptly_after_stop() -> Result<()> {
     dotenvy::dotenv_override().ok();
     let _ = tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,11 +1,77 @@
-use std::time::Duration;
+use std::env;
+use std::time::{Duration, Instant};
 
+use anyhow::{Context, Result};
 use helper::*;
-use serde_json::Value;
+use serde_json::{Value, json};
 use tokio::sync::mpsc::{channel, unbounded_channel};
+use tokio::time::{interval, timeout};
+use tracing_subscriber::EnvFilter;
 
-use crate::{ClientEvent, ContextSwitch, ConversationId, Registry, ServerEvent};
-use context_switch_core::InputModality;
+use crate::{
+    AudioFormat, ClientEvent, ContextSwitch, ConversationId, InputModality, OutputModality,
+    Registry, ServerEvent, registry,
+};
+
+// Azure does not finish its recognition stream after ContextSwitch closes the input on Stop.
+// ContextSwitch therefore waits for its three-second shutdown grace period, logs the timeout,
+// and then emits Stopped. Late transcription output cannot be delivered during that period.
+#[tokio::test]
+#[ignore = "requires Azure credentials and runs for about 8 seconds"]
+async fn azure_transcribe_logs_graceful_shutdown_timeout_after_stop() -> Result<()> {
+    dotenvy::dotenv_override().ok();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_test_writer()
+        .try_init();
+
+    let (server_sender, mut server_receiver) = unbounded_channel();
+    let mut context_switch = ContextSwitch::new(registry().into(), server_sender, None);
+    let conversation_id: ConversationId = "azure-shutdown-regression".to_string().into();
+    let audio_format = AudioFormat::new(1, 16_000);
+
+    context_switch.process(ClientEvent::Start {
+        id: conversation_id.clone(),
+        service: "azure-transcribe".into(),
+        params: azure_transcribe_params()?,
+        input_modality: InputModality::Audio {
+            format: audio_format,
+        },
+        output_modalities: vec![OutputModality::Text, OutputModality::InterimText],
+        billing_id: None,
+    })?;
+
+    let started = timeout(Duration::from_secs(10), server_receiver.recv())
+        .await
+        .context("Azure transcribe did not start")?
+        .context("Azure transcribe output channel closed before start")?;
+    assert!(matches!(started, ServerEvent::Started { .. }));
+
+    let audio_deadline = Instant::now() + Duration::from_secs(5);
+    let mut audio_interval = interval(Duration::from_millis(20));
+    while Instant::now() < audio_deadline {
+        audio_interval.tick().await;
+        context_switch.post_audio_frame(
+            &conversation_id,
+            crate::AudioFrame {
+                format: audio_format,
+                samples: vec![0; 320],
+            },
+        )?;
+    }
+
+    context_switch.process(ClientEvent::Stop {
+        id: conversation_id.clone(),
+    })?;
+
+    let stopped = timeout(Duration::from_secs(5), server_receiver.recv())
+        .await
+        .context("ContextSwitch did not stop Azure transcribe")?
+        .context("Azure transcribe output channel closed before stop")?;
+    assert!(matches!(stopped, ServerEvent::Stopped { id } if id == conversation_id));
+
+    Ok(())
+}
 
 #[tokio::test]
 async fn never_ending_service_shut_downs_gracefully_in_response_to_stop() {
@@ -78,6 +144,26 @@ async fn params_deserialization_failure_is_emitted_as_conversation_error() {
     assert_eq!(id, conv);
     assert!(message.contains("Conversation: `conv-deser-fail`"));
     assert!(message.contains("Failed to deserialize service params"));
+}
+
+fn azure_transcribe_params() -> Result<Value> {
+    let endpoint = env::var("AZURE_ENDPOINT")
+        .ok()
+        .or_else(|| env::var("AZURE_HOST").ok());
+    let region = env::var("AZURE_REGION").ok();
+    if endpoint.is_none() && region.is_none() {
+        anyhow::bail!("AZURE_ENDPOINT, AZURE_HOST, or AZURE_REGION must be set");
+    }
+
+    let subscription_key = env::var("AZURE_SUBSCRIPTION_KEY")
+        .context("AZURE_SUBSCRIPTION_KEY must be set for Azure shutdown regression test")?;
+
+    Ok(json!({
+        "endpoint": endpoint,
+        "region": region,
+        "subscriptionKey": subscription_key,
+        "language": "en-US",
+    }))
 }
 
 // This is currently a limitation. No output events can be sent while a graceful shutdown has


### PR DESCRIPTION
After we stopped audio, the following appeared in the log:

```2026-08-05T12:09:13.048499Z ERROR context_switch::context_switch: Graceful shutdown period expired after waiting for 3000ms```

 Even though this situation is handled by sending an empty audio frame in azure-speech-sdk, the session is restarted and the event stream stays open.

The updates in the azure-speech-sdk submodule won't restart the session and wait for it to end and then ends the event stream.